### PR TITLE
inventory fixes

### DIFF
--- a/characters/player/Player.gd
+++ b/characters/player/Player.gd
@@ -29,8 +29,10 @@ func _input(event):
 	if is_network_master():
 		if Input.is_key_pressed(KEY_W):
 			if has_node("PlayerInventory"):
+				set_physics_process(true)
 				remove_child(inventory)
 			else:
+				set_physics_process(false)
 				add_child(inventory)
 			
 

--- a/characters/player/ui/inventory/Inventory.gd
+++ b/characters/player/ui/inventory/Inventory.gd
@@ -84,7 +84,8 @@ func _ready():
 
 func _input(event):
 	if holdingItem != null && holdingItem.picked:
-		holdingItem.rect_global_position = Vector2(event.position.x, event.position.y);
+		var mousePos = get_global_mouse_position()
+		holdingItem.rect_global_position = Vector2(mousePos.x, mousePos.y);
 
 func _gui_input(event):
 	if event is InputEventMouseButton and event.button_index == BUTTON_LEFT and event.pressed:


### PR DESCRIPTION
Don't move player when clicks inside inventory occur. Items clicked should follow the mouse position.